### PR TITLE
harden caron

### DIFF
--- a/caron.js
+++ b/caron.js
@@ -20,7 +20,7 @@ class Caron {
 
     this.ptype = opts.type
     this.freq = opts.freq
-    this.kill = opts.kill || true
+    this.exit = opts.exit || true
 
     this.redis = Redis.createClient(opts.redis)
     this.registerHandlers()
@@ -52,7 +52,7 @@ class Caron {
   }
 
   kill () {
-    if (!this.kill) return
+    if (!this.exit) return
     process.exit()
   }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -28,7 +28,7 @@ describe('integration', () => {
       def_queue: 'default',
       def_worker: 'BaseJob',
       def_attempts: 1,
-      kill: false,
+      exit: false,
       debug: false
     })
 


### PR DESCRIPTION
found a small bug while testing:

`this.kill = opts.kill || true` was overwriting the method kill on the class.